### PR TITLE
refactor: update dockerfile for fix deprecated error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:14.04
 
 ENV USER=ftpuser
 ENV PASS=changeme

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM ubuntu:14.04
-MAINTAINER Emily Bache
+FROM ubuntu:24.04
 
-ENV USER ftpuser
-ENV PASS changeme
+ENV USER=ftpuser
+ENV PASS=changeme
 
 RUN apt-get update && \
     apt-get install -y vsftpd supervisor && \


### PR DESCRIPTION
For avoid the following error

Unable to find image 'emilybache/vsftpd-server:latest' locally
latest: Pulling from emilybache/vsftpd-server
docker: [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/emilybache/vsftpd-server:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/.